### PR TITLE
[ES]: Agregado de shortcuts al color picker / [EN]: Adding color picker shortcuts

### DIFF
--- a/components/ColorPicker.tsx
+++ b/components/ColorPicker.tsx
@@ -1,26 +1,44 @@
 import { type Signal } from "@preact/signals";
-import { COLORS } from "../shared/constants.ts";
+import { COLORS, COLORS_KEYBOARD_MAP } from "../shared/constants.ts";
 import { Color } from "../shared/types.ts";
+import { useCallback, useEffect } from "preact/hooks";
 
 export function ColorPicker({
   selected,
 }: {
   selected: Signal<Color>;
 }) {
+  const shortcutsHandler = useCallback((e: KeyboardEvent) => {
+    const { code } = e;
+    selected.value =
+      COLORS_KEYBOARD_MAP[code as keyof typeof COLORS_KEYBOARD_MAP] ||
+      selected.value;
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", shortcutsHandler);
+    return () => {
+      document.removeEventListener("keydown", shortcutsHandler);
+    };
+  }, []);
+
   return (
     <footer class="flex gap-8">
       <div class="flex fixed bottom-4 justify-center left-0 right-0 gap-x-1">
-        {COLORS.map((color) => (
-          <button
-            class={`
-            w-8 h-8 border-4
+        {COLORS.map((color, idx) => (
+          <div class="relative flex items-center justify-center flex-col">
+            <button
+              class={`
+              w-8 h-8 border-4
               ${selected.value === color ? "border-white" : "border-gray-800"}
-            `}
-            style={`background-color: ${color};`}
-            onClick={() => {
-              selected.value = color;
-            }}
-          />
+              `}
+              style={`background-color: ${color};`}
+              onClick={() => {
+                selected.value = color;
+              }}
+            />
+            <span class="text-xs">{idx + 1}</span>
+          </div>
         ))}
       </div>
     </footer>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -23,3 +23,14 @@ export const KEYS = {
 export const CHANNELS = {
   PIXEL_UPDATE: "pixel-update",
 };
+
+export const COLORS_KEYBOARD_MAP = {
+  Digit1: COLORS_NAMES.red,
+  Digit2: COLORS_NAMES.green,
+  Digit3: COLORS_NAMES.blue,
+  Digit4: COLORS_NAMES.yellow,
+  Digit5: COLORS_NAMES.brightBlue,
+  Digit6: COLORS_NAMES.pink,
+  Digit7: COLORS_NAMES.white,
+  Digit8: COLORS_NAMES.black,
+};


### PR DESCRIPTION
[ES]
# Descripción
Agregado de shortcuts para cambiar color del picker. Basado en los shorctus de minecraft (en este caso de oprimiendo las teclas desde el 1 al 8).

# Captura de Imagen
![image](https://github.com/midudev/pixel-wars/assets/3083587/4ac0601e-4496-4c53-bdb8-073bdfcf23e2)


[EN]
# Description
Adding color picker shortcuts based on Minecraft shorctus (it's mean pressing 1 to 8 keys)

# Screenshot
![image](https://github.com/midudev/pixel-wars/assets/3083587/4ac0601e-4496-4c53-bdb8-073bdfcf23e2)